### PR TITLE
Expose MemoryView for direct use

### DIFF
--- a/src/Interprocess/Contracts/MemoryViewOptions.cs
+++ b/src/Interprocess/Contracts/MemoryViewOptions.cs
@@ -1,0 +1,56 @@
+﻿using static Cloudtoid.Contract;
+using SysPath = System.IO.Path;
+
+namespace Cloudtoid.Interprocess;
+
+/// <summary> The options to create a raw memory view. </summary>
+public class MemoryViewOptions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MemoryViewOptions"/> class.
+    /// </summary>
+    /// <param name="memoryViewName">The unique name of the memory view.</param>
+    /// <param name="capacity">The maximum capacity of the memory view in bytes. This should be at least 16 bytes long and in the multiples of 8</param>
+    public MemoryViewOptions(string memoryViewName, long capacity)
+        : this(memoryViewName, SysPath.GetTempPath(), capacity)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="QueueOptions"/> class.
+    /// </summary>
+    /// <param name="memoryViewName">The unique name of the queue.</param>
+    /// <param name="path">The path to the directory/folder in which the memory mapped and other files are stored in</param>
+    /// <param name="capacity">The maximum capacity of the queue in bytes. This should be at least 16 bytes long and in the multiples of 8</param>
+    public unsafe MemoryViewOptions(string memoryViewName, string path, long capacity)
+    {
+        MemoryViewName = CheckNonEmpty(memoryViewName, nameof(memoryViewName));
+        Path = CheckValue(path, nameof(path));
+
+        Capacity = CheckGreaterThan(capacity, 16, nameof(capacity));
+        CheckParam(
+            (capacity % 8) == 0,
+            nameof(memoryViewName),
+            "messageCapacityInBytes should be a multiple of 8 (8 bytes = 64 bits).");
+    }
+
+    /// <summary>
+    /// Gets the unique name of the memory view.
+    /// </summary>
+    public string MemoryViewName { get; }
+
+    /// <summary>
+    /// Gets the path to the directory/folder in which the memory mapped and other files are stored in.
+    /// </summary>
+    public string Path { get; }
+
+    /// <summary>
+    /// Gets the size of the memory view in bytes.
+    /// </summary>
+    public long Capacity { get; }
+
+    /// <summary>
+    /// Gets the full size of this memory view. For raw memory view this is the same as Capacity.
+    /// </summary>
+    public virtual long GetActualStorageSize() => Capacity;
+}

--- a/src/Interprocess/Contracts/QueueOptions.cs
+++ b/src/Interprocess/Contracts/QueueOptions.cs
@@ -1,10 +1,7 @@
-using static Cloudtoid.Contract;
-using SysPath = System.IO.Path;
-
 namespace Cloudtoid.Interprocess;
 
 /// <summary> The options to create a queue. </summary>
-public sealed class QueueOptions
+public sealed class QueueOptions : MemoryViewOptions
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="QueueOptions"/> class.
@@ -12,7 +9,7 @@ public sealed class QueueOptions
     /// <param name="queueName">The unique name of the queue.</param>
     /// <param name="capacity">The maximum capacity of the queue in bytes. This should be at least 16 bytes long and in the multiples of 8</param>
     public QueueOptions(string queueName, long capacity)
-        : this(queueName, SysPath.GetTempPath(), capacity)
+        : base(queueName, capacity)
     {
     }
 
@@ -23,34 +20,12 @@ public sealed class QueueOptions
     /// <param name="path">The path to the directory/folder in which the memory mapped and other files are stored in</param>
     /// <param name="capacity">The maximum capacity of the queue in bytes. This should be at least 16 bytes long and in the multiples of 8</param>
     public unsafe QueueOptions(string queueName, string path, long capacity)
+        : base(queueName, path, capacity)
     {
-        QueueName = CheckNonEmpty(queueName, nameof(queueName));
-        Path = CheckValue(path, nameof(path));
-
-        Capacity = CheckGreaterThan(capacity, 16, nameof(capacity));
-        CheckParam(
-            (capacity % 8) == 0,
-            nameof(queueName),
-            "messageCapacityInBytes should be a multiple of 8 (8 bytes = 64 bits).");
     }
-
-    /// <summary>
-    /// Gets the unique name of the queue.
-    /// </summary>
-    public string QueueName { get; }
-
-    /// <summary>
-    /// Gets the path to the directory/folder in which the memory mapped and other files are stored in.
-    /// </summary>
-    public string Path { get; }
-
-    /// <summary>
-    /// Gets the size of the queue in bytes. This does NOT include the space needed for the queue header.
-    /// </summary>
-    public long Capacity { get; }
 
     /// <summary>
     /// Gets the full size of the queue that includes both the header and message sections
     /// </summary>
-    internal unsafe long GetQueueStorageSize() => sizeof(QueueHeader) + Capacity;
+    public override unsafe long GetActualStorageSize() => sizeof(QueueHeader) + base.GetActualStorageSize();
 }

--- a/src/Interprocess/Memory/MemoryFileUnix.cs
+++ b/src/Interprocess/Memory/MemoryFileUnix.cs
@@ -15,13 +15,13 @@ internal sealed class MemoryFileUnix : IMemoryFile
 #pragma warning restore CA2213 // Disposable fields should be disposed
     private readonly ILogger<MemoryFileUnix> logger;
 
-    internal MemoryFileUnix(QueueOptions options, ILoggerFactory loggerFactory)
+    internal MemoryFileUnix(MemoryViewOptions options, ILoggerFactory loggerFactory)
     {
         logger = loggerFactory.CreateLogger<MemoryFileUnix>();
         file = Path.Combine(options.Path, Folder);
         Directory.CreateDirectory(file);
-        lockFile = Path.Combine(file, options.QueueName + LockExtension);
-        file = Path.Combine(file, options.QueueName + FileExtension);
+        lockFile = Path.Combine(file, options.MemoryViewName + LockExtension);
+        file = Path.Combine(file, options.MemoryViewName + FileExtension);
         counter = new AtomicFileCounter(lockFile, _ => ResetBackingFile(), out _);
 
         try

--- a/src/Interprocess/Memory/MemoryFileWindows.cs
+++ b/src/Interprocess/Memory/MemoryFileWindows.cs
@@ -6,15 +6,15 @@ internal sealed class MemoryFileWindows : IMemoryFile
 {
     private const string MapNamePrefix = "CT_IP_";
 
-    internal MemoryFileWindows(QueueOptions options)
+    internal MemoryFileWindows(MemoryViewOptions options)
     {
 #if NET5_0_OR_GREATER
         if (!OperatingSystem.IsWindows())
             throw new PlatformNotSupportedException();
 #endif
         MappedFile = MemoryMappedFile.CreateOrOpen(
-            mapName: MapNamePrefix + options.QueueName,
-            options.GetQueueStorageSize(),
+            mapName: MapNamePrefix + options.MemoryViewName,
+            options.GetActualStorageSize(),
             MemoryMappedFileAccess.ReadWrite,
             MemoryMappedFileOptions.None,
             HandleInheritability.None);

--- a/src/Interprocess/Memory/MemoryView.cs
+++ b/src/Interprocess/Memory/MemoryView.cs
@@ -7,12 +7,12 @@ using SysPath = System.IO.Path;
 namespace Cloudtoid.Interprocess;
 
 // This class manages the underlying Memory Mapped File
-internal sealed class MemoryView : IDisposable
+public sealed class MemoryView : IDisposable
 {
     private readonly IMemoryFile file;
     private readonly MemoryMappedViewAccessor view;
 
-    internal unsafe MemoryView(QueueOptions options, ILoggerFactory loggerFactory)
+    public unsafe MemoryView(MemoryViewOptions options, ILoggerFactory loggerFactory)
     {
         // Check if the path is different from the default temp path and use the Unix one instead.
         // This allows defining a custom map location, even on Windows. Though it's also useful for
@@ -44,7 +44,11 @@ internal sealed class MemoryView : IDisposable
             }
     }
 
+#pragma warning disable CA1720 // This is quite literally... a pointer.
     public unsafe byte* Pointer { get; }
+#pragma warning restore CA1720
+
+    public unsafe Span<byte> Data => new(Pointer, (int)view.Capacity);
 
     public void Dispose()
     {

--- a/src/Interprocess/Queue/Publisher.cs
+++ b/src/Interprocess/Queue/Publisher.cs
@@ -5,7 +5,7 @@ internal sealed class Publisher : Queue, IPublisher
     private readonly IInterprocessSemaphoreReleaser signal;
 
     internal Publisher(QueueOptions options, ILoggerFactory loggerFactory)
-        : base(options, loggerFactory) => signal = InterprocessSemaphore.CreateReleaser(options.QueueName);
+        : base(options, loggerFactory) => signal = InterprocessSemaphore.CreateReleaser(options.MemoryViewName);
 
     public unsafe bool TryEnqueue(ReadOnlySpan<byte> message)
     {

--- a/src/Interprocess/Queue/Subscriber.cs
+++ b/src/Interprocess/Queue/Subscriber.cs
@@ -8,7 +8,7 @@ internal sealed class Subscriber : Queue, ISubscriber
     private readonly IInterprocessSemaphoreWaiter signal;
 
     internal Subscriber(QueueOptions options, ILoggerFactory loggerFactory)
-        : base(options, loggerFactory) => signal = InterprocessSemaphore.CreateWaiter(options.QueueName);
+        : base(options, loggerFactory) => signal = InterprocessSemaphore.CreateWaiter(options.MemoryViewName);
 
     public bool TryDequeue(CancellationToken cancellation, out ReadOnlyMemory<byte> message) =>
         TryDequeueCore(default, cancellation, out message);


### PR DESCRIPTION
For our use-case we need both queue system for messaging, but also ability to create and manage our own raw memory views. 

This PR exposes those to be usable directly outside of the queues.