### PR TITLE
Check availability of SHM Bridge library before using it

### DIFF
--- a/src/Interprocess/Semaphore/InterprocessSemaphore.cs
+++ b/src/Interprocess/Semaphore/InterprocessSemaphore.cs
@@ -14,7 +14,7 @@ internal static class InterprocessSemaphore
 {
     internal static IInterprocessSemaphoreWaiter CreateWaiter(string name)
     {
-        if (Util.IsWine)
+        if (UseWine)
             return new SemaphoreWine(name);
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -28,7 +28,7 @@ internal static class InterprocessSemaphore
 
     internal static IInterprocessSemaphoreReleaser CreateReleaser(string name)
     {
-        if (Util.IsWine)
+        if (UseWine)
             return new SemaphoreWine(name);
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -39,4 +39,6 @@ internal static class InterprocessSemaphore
 
         return new SemaphoreLinux(name);
     }
+
+    private static readonly bool UseWine = Util.IsWine && Semaphore.Wine.Interop.ShmBridgeAvailable;
 }

--- a/src/Interprocess/Semaphore/Wine/Interop.cs
+++ b/src/Interprocess/Semaphore/Wine/Interop.cs
@@ -5,6 +5,21 @@ namespace Cloudtoid.Interprocess.Semaphore.Wine;
 
 internal static partial class Interop
 {
+    internal static readonly bool ShmBridgeAvailable;
+
+    static Interop()
+    {
+        try
+        {
+            SemaphoreClose(IntPtr.Zero);
+            ShmBridgeAvailable = true;
+        }
+        catch
+        {
+            // Must fall back to Windows semaphores
+        }
+    }
+
     private const string Lib = "shmbridge.dll.so";
     private const uint SEMVALUEMAX = 32767;
     private const int OCREAT = 0x040;    // Create the semaphore if it does not exist


### PR DESCRIPTION
When using the Interprocess library on a homogeneous system (full Linux or full Windows) the current semaphore implementations work perfectly well.
However, when mixing a Linux native program with a Windows program running on Wine, the native semaphores from both sides are distinct and can not communicate. This forces the queue implementation to just wait dumbly on a spinlock until the new data is available.

With these new changes, I have created a thin winelib DLL that wraps directly the native Linux sem_* functions. When the process detects that it is running in Wine, it will switch to using that provided DLL (if available in the libraries of the calling program). This allows the Wine guest program to effectively use Linux semaphors, bridging the gap described above.

I have not figured out the proper way to package the generated DLL yet. It has to be built on a Linux system with wine and gcc available, so it can’t be immediately integrated into a MSBuild project. I have left the compiled DLL into the build folder for now.
To be made available to the Wine process, it just needs to be located in the same folder as other DLLs used by the program. For example, for Unity games, this is generally <ProgramName>_Data/Managed .