### PR TITLE
Workaround IL2CPP missing support for Console.CancelKeyPress

### DIFF
--- a/src/Interprocess/Queue/Queue.cs
+++ b/src/Interprocess/Queue/Queue.cs
@@ -23,7 +23,17 @@ internal abstract class Queue : IDisposable
         // must clean up if the application is being closed but finalizer is not called.
         // this happens in cases such as closing a console app by pressing the X button.
         AppDomain.CurrentDomain.ProcessExit += OnAppExit;
-        Console.CancelKeyPress += OnAppExit;
+        try
+        {
+            Console.CancelKeyPress += OnAppExit;
+        }
+        catch (NotSupportedException)
+        {
+            // ignored. this happens in Unity IL2CPP due to static marshaling nonsense.
+            // we can't patch System.Console+WindowsConsole::DoWindowsConsoleCancelEvent
+            // to add 'MonoPInvokeCallback' so we just have to ignore here.
+            // this particular event is unlikely to trigger in Unity anyway
+        }
     }
 
     ~Queue() =>


### PR DESCRIPTION
This gets the IL2CPP renderer a little further into initialization.

When setting up a queue, Interprocess will setup an event handler with the console's ^C handler to shutdown cleanly when the process is exited via the console.

This ends up calling a method in Mono named `WindowsConsole::DoWindowsConsoleCancelEvent` which is missing a `MonoPInvokeCallback` attribute, which is **required** for managed methods under IL2CPP. This ends up throwing a `NotSupportedException`:

```csharp
Failed to connect to the controller:
System.NotSupportedException: To marshal a managed method, please add an attribute named 'MonoPInvokeCallback' to the method definition. The method we're attempting to marshal is: System.Console+WindowsConsole::DoWindowsConsoleCancelEvent
  at System.Console+WindowsConsole.SetConsoleCtrlHandler (System.Console+WindowsConsole+WindowsCancelHandler handler, System.Boolean addHandler) [0x00000] in <00000000000000000000000000000000>:0 
  at System.Console.add_CancelKeyPress (System.ConsoleCancelEventHandler value) [0x00000] in <00000000000000000000000000000000>:0 
  at Cloudtoid.Interprocess.Queue..ctor (Cloudtoid.Interprocess.QueueOptions options, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) [0x00000] in <00000000000000000000000000000000>:0 
  at Cloudtoid.Interprocess.Publisher..ctor (Cloudtoid.Interprocess.QueueOptions options, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) [0x00000] in <00000000000000000000000000000000>:0 
  at Cloudtoid.Interprocess.QueueFactory.CreatePublisher (Cloudtoid.Interprocess.QueueOptions options) [0x00000] in <00000000000000000000000000000000>:0 
  at Renderite.Shared.MessagingManager.Connect (System.String queueName, System.Boolean isAuthority, System.Int64 capacity) [0x00000] in <00000000000000000000000000000000>:0 
  at Renderite.Unity.RenderingManager.Awake () [0x00000] in <00000000000000000000000000000000>:0 
```

We can't modify Mono here easily, so to fix, just catch and ignore that particular exception.

Related to https://github.com/Yellow-Dog-Man/Renderite.Unity.Renderer/issues/2
