### PR TITLE
Only use /dev/shm if we're actually on Linux (not just any UNIX)

### DIFF
--- a/src/Interprocess/Util.cs
+++ b/src/Interprocess/Util.cs
@@ -13,7 +13,7 @@ internal static class Util
     private const string LINUX_SHM_DIR = "/dev/shm";
     static Util()
     {
-        bool isLinux = Environment.OSVersion.Platform == PlatformID.Unix;
+        bool isLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
         IsMonoUnderLinux = isLinux && Type.GetType("Mono.Runtime") is not null;
 
         try


### PR DESCRIPTION
Related: https://github.com/Yellow-Dog-Man/Resonite-Issues/issues/1412, https://github.com/Yellow-Dog-Man/Renderite.Unity.Renderer/issues/18

This changes the behaviour of using `/dev/shm` on all UNIXes and using the tempdir on Windows, to only use `/dev/shm` on Linux, as well, it doesn't exist on anything other than Linux (https://en.wikipedia.org/wiki/Shared_memory#Support_on_Unix-like_systems)