### PR TITLE
Rewrite SemaphoreWindows to use P/Invokes

### DIFF
--- a/src/Interprocess/Semaphore/Windows/Interop.cs
+++ b/src/Interprocess/Semaphore/Windows/Interop.cs
@@ -1,0 +1,69 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+#if NET9_0_OR_GREATER
+using System.Runtime.InteropServices.Marshalling;
+#endif
+
+namespace Cloudtoid.Interprocess.Semaphore.Windows;
+
+public static partial class Interop
+{
+    private const string Lib = "kernel32.dll";
+
+    private const uint WAIT_ABANDONED = 0x00000080;
+    private const uint WAIT_OBJECT_0 = 0x00000000;
+    private const uint WAIT_TIMEOUT = 0x00000102;
+    private const uint WAIT_FAILED = 0xFFFFFFFF;
+
+    internal static SafeWaitHandle CreateOrOpenSemaphore(string name)
+    {
+        var handle = CreateSemaphoreA(IntPtr.Zero, 0, int.MaxValue, name);
+        if (handle.IsInvalid)
+            throw new Win32Exception();
+
+        return handle;
+    }
+
+    internal static bool Wait(SafeWaitHandle handle, int millisecondsTimeout)
+    {
+        var result = WaitForSingleObject(handle, millisecondsTimeout);
+        return result switch
+        {
+            WAIT_OBJECT_0 => true,
+            WAIT_TIMEOUT => false,
+            WAIT_ABANDONED => throw new AbandonedMutexException(),
+            WAIT_FAILED => throw new Win32Exception(),
+            _ => throw new Exception($"Unknown wait result 0x{result:x8}")
+        };
+    }
+
+    internal static void Release(SafeWaitHandle handle)
+    {
+        bool success = ReleaseSemaphore(handle, 1, IntPtr.Zero);
+        if (!success)
+            throw new Win32Exception();
+    }
+
+#if NET9_0_OR_GREATER
+    [LibraryImport(Lib, EntryPoint = "CreateSemaphoreA", SetLastError = true, StringMarshallingCustomType = typeof(AnsiStringMarshaller))]
+    private static partial SafeWaitHandle CreateSemaphoreA(IntPtr lpSemaphoreAttributes, int lInitialCount, int lMaximumCount, string lpName);
+
+    [LibraryImport(Lib, EntryPoint = "WaitForSingleObject", SetLastError = true)]
+    private static partial uint WaitForSingleObject(SafeWaitHandle hHandle, int dwMilliseconds);
+
+    [LibraryImport(Lib, EntryPoint = "ReleaseSemaphore", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool ReleaseSemaphore(SafeWaitHandle hSemaphore, int lReleaseCount, IntPtr lpPreviousCount);
+#else
+    [DllImport(Lib, EntryPoint = "CreateSemaphoreA", SetLastError = true, CharSet = CharSet.Ansi)]
+    private static extern SafeWaitHandle CreateSemaphoreA(IntPtr lpSemaphoreAttributes, int lInitialCount, int lMaximumCount, string lpName);
+
+    [DllImport(Lib, EntryPoint = "WaitForSingleObject", SetLastError = true)]
+    private static extern uint WaitForSingleObject(SafeWaitHandle hHandle, int dwMilliseconds);
+
+    [DllImport(Lib, EntryPoint = "ReleaseSemaphore", SetLastError = true)]
+    private static extern bool ReleaseSemaphore(SafeWaitHandle hSemaphore, int lReleaseCount, IntPtr lpPreviousCount);
+#endif
+}

--- a/src/Interprocess/Semaphore/Windows/SemaphoreWindows.cs
+++ b/src/Interprocess/Semaphore/Windows/SemaphoreWindows.cs
@@ -1,22 +1,19 @@
-using SysSemaphore = System.Threading.Semaphore;
+using Microsoft.Win32.SafeHandles;
 
 namespace Cloudtoid.Interprocess.Semaphore.Windows;
 
 // just a wrapper over the Windows named semaphore
+// ideally, .NET's own semaphore implementation would be used however on IL2CPP support for named semaphores are missing.
 internal sealed class SemaphoreWindows : IInterprocessSemaphoreWaiter, IInterprocessSemaphoreReleaser
 {
     private const string HandleNamePrefix = @"Global\CT.IP.";
-    private readonly SysSemaphore handle;
+    private readonly SafeWaitHandle handle;
 
-    internal SemaphoreWindows(string name) =>
-        handle = new SysSemaphore(0, int.MaxValue, HandleNamePrefix + name);
+    internal SemaphoreWindows(string name) => handle = Interop.CreateOrOpenSemaphore(HandleNamePrefix + name);
 
-    public void Dispose() =>
-        handle.Dispose();
+    public void Dispose() => handle.Dispose();
 
-    public void Release() =>
-        handle.Release();
+    public void Release() => Interop.Release(handle);
 
-    public bool Wait(int millisecondsTimeout) =>
-        handle.WaitOne(millisecondsTimeout);
+    public bool Wait(int millisecondsTimeout) => Interop.Wait(handle, millisecondsTimeout);
 }


### PR DESCRIPTION
For some reason, the named semaphore implementation in IL2CPP is a stub that throws an exception saying it isn't supported:
<img width="1121" height="684" alt="image" src="https://github.com/user-attachments/assets/cad43954-6b55-40ae-a033-ab9ade0515ef" />

I'm not sure why this is, because my solution is what it would normally do in Mono anyways, but to workaround this we can use P/Invokes on Windows to just run the semaphore calls ourselves.

This also happens to neatly align with what the Linux and Mac implementations do.

Related to https://github.com/Yellow-Dog-Man/Renderite.Unity.Renderer/issues/2
